### PR TITLE
Remove doming

### DIFF
--- a/Configuration.h
+++ b/Configuration.h
@@ -84,7 +84,7 @@
 #define DELTA_DIAGONAL_ROD 290.5 // mm
 
 // Horizontal offset from middle of printer to smooth rod center.
-#define DELTA_SMOOTH_ROD_OFFSET 220.929  // mm
+#define DELTA_SMOOTH_ROD_OFFSET 221.65  // mm
 
 // Horizontal offset of the universal joints on the end effector.
 #define DELTA_EFFECTOR_OFFSET 33 // mm
@@ -335,7 +335,7 @@ const bool Z_ENDSTOPS_INVERTING = false; // set to true to invert the logic of t
 // For deltabots this means top and center of the cartesian print volume.
 #define MANUAL_X_HOME_POS 0
 #define MANUAL_Y_HOME_POS 0
-#define MANUAL_Z_HOME_POS 300.5738  // For delta: Distance between nozzle and print surface after homing.
+#define MANUAL_Z_HOME_POS 300.7162  // For delta: Distance between nozzle and print surface after homing.
 
 //// MOVEMENT SETTINGS
 #define NUM_AXIS 4 // The axis order in all axis related arrays is X, Y, Z, E


### PR DESCRIPTION
I ran a manual calibration on Friday Mar 25. The only changes were to the DELTA_SMOOTH_ROD_OFFSET and MANUAL_Z_HOME_POS. Commit 1f69603 added six mm to the smooth rod offset, which seems to be incorrect for our Kossel.